### PR TITLE
Introduce environment variable to set Application Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Coverage Status](https://codecov.io/gh/tembici/temlogger/branch/master/graph/badge.svg)](https://codecov.io/gh/tembici/temlogger)
 
 # TemLogger
-**Temlogger** is a library that help send logs to different providers such ELK, StackDriver(Google Cloud Logging). 
+**Temlogger** is a library to sends logs to providers such as ELK and StackDriver(Google Cloud Logging).
 Temlogger can be used in any python 3.6+ application.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![Coverage Status](https://codecov.io/gh/tembici/temlogger/branch/master/graph/badge.svg)](https://codecov.io/gh/tembici/temlogger)
 
 # TemLogger
-**Temlogger** is a library to send logs to ELK, StackDriver(Google Cloud Logging).
+**Temlogger** is a library that help send logs to different providers such ELK, StackDriver(Google Cloud Logging). 
+Temlogger can be used in any python 3.6+ application.
 
 ## Features
 
@@ -32,72 +33,47 @@ Temlogger gives you:
     pip install temlogger
 
 
-## Usage
+## Configuration
 
-### How to use temlogger
+Temlogger can be used with environment variables or programmatically.
 
-#### Can be used with environment variables:
+Example of configuration with environment variables to Console provider:
 
 ```bash
+export TEMLOGGER_APP_NAME='your-app-name'
 export TEMLOGGER_PROVIDER='console'
 export TEMLOGGER_ENVIRONMENT='staging'
-export TEMLOGGER_LOG_LEVEL='INFO' #Default: INFO, Acceptable values: DEBUG, INFO, WARNING, ERROR, FATAL, CRITICAL
+export TEMLOGGER_LOG_LEVEL='INFO'
 ```
 
 ```python
 import sys
 import temlogger
 
-test_logger = temlogger.getLogger('python-console-logger')
-
-test_logger.error('python-console: test console error message.')
 test_logger.info('python-console: test console info message.')
 test_logger.debug('python-console: debug message will not be displayed. Change level to "DEBUG"')
 test_logger.warning('python-console: test console warning message.')
-
-# add extra field to console message
-extra = {
-    'test_string': 'python version: ' + repr(sys.version_info),
-    'test_boolean': True,
-    'test_dict': {'a': 1, 'b': 'c'},
-    'test_float': 1.23,
-    'test_integer': 123,
-    'test_list': [1, 2, '3'],
-}
-test_logger.info('temlogger: test with extra fields', extra=extra)
 ```
 
-#### Can be used with explict parameters:
-
-Example passing parameters directly to temlogger:
+Example of configuration programmatically to Console provider:
 
 ```python
 import sys
 import temlogger
 
+temlogger.config.set_app_name('your-app-name')
 temlogger.config.set_provider('console')
 temlogger.config.set_environment('staging')
 temlogger.config.set_log_level('INFO')
 
-test_logger = temlogger.getLogger('python-console-logger')
-
 test_logger.info('python-console: test console info message.')
 test_logger.debug('python-console: debug message will not be displayed. Change level to "DEBUG"')
-
-# add extra field to console message
-extra = {
-    'test_string': 'python version: ' + repr(sys.version_info),
-    'test_boolean': True,
-    'test_dict': {'a': 1, 'b': 'c'},
-    'test_float': 1.23,
-    'test_integer': 123,
-    'test_list': [1, 2, '3'],
-}
-test_logger.info('temlogger: test with extra fields', extra=extra)
+test_logger.warning('python-console: test console warning message.')
 ```
 
-### Required parameters to setup Logstash Provider
+### Parameters to setup Logstash Provider
 
+    export TEMLOGGER_APP_NAME='your-app-name'
     export TEMLOGGER_PROVIDER='logstash'
     export TEMLOGGER_URL='<logstash url>'
     export TEMLOGGER_PORT='<logstash port>'
@@ -105,9 +81,10 @@ test_logger.info('temlogger: test with extra fields', extra=extra)
     export TEMLOGGER_LOG_LEVEL='INFO'
 
 
-### Required parameters to setup StackDriver Provider
+### Parameters to setup StackDriver Provider
 The variable `GOOGLE_APPLICATION_CREDENTIALS` is now deprecated and your use isn't recommended. Use `TEMLOGGER_GOOGLE_CREDENTIALS_BASE64` instead. 
 
+    export TEMLOGGER_APP_NAME='your-app-name'
     export TEMLOGGER_PROVIDER='stackdriver'
     export TEMLOGGER_ENVIRONMENT='<your environment>'
     export TEMLOGGER_GOOGLE_CREDENTIALS_BASE64='<your google json creds as base64>'
@@ -118,19 +95,23 @@ To encode your google credentials use:
 ```bash
 base64 <google application credentials path>
 ```
-### Required parameters to setup Console Provider
+### Parameters to setup Console Provider
 
     export TEMLOGGER_PROVIDER='console'
     export TEMLOGGER_ENVIRONMENT='<your environment>'
     export TEMLOGGER_LOG_LEVEL='INFO'
 
 
+## Usage Examples
+
 ### Example with StackDriver
 
 If you have a Google Credentials, step ahead. If not, create one here https://console.cloud.google.com/apis/credentials/serviceaccountkey. It's recomended to assign just the needed permissions (`logging > write logs`).
 ```bash
+export TEMLOGGER_APP_NAME='your-app-name'
 export TEMLOGGER_PROVIDER='stackdriver'
 export TEMLOGGER_GOOGLE_CREDENTIALS_BASE64='<your google json creds as base64>'
+export TEMLOGGER_ENVIRONMENT='staging'
 export TEMLOGGER_LOG_LEVEL='INFO'
 ```
 
@@ -157,6 +138,7 @@ logger.info('temlogger: test with extra fields', extra=extra)
 ### Example with LogStash
 
 ```bash
+export TEMLOGGER_APP_NAME='your-app-name'
 export TEMLOGGER_PROVIDER='logstash'
 export TEMLOGGER_URL='localhost'
 export TEMLOGGER_PORT='5000'
@@ -188,6 +170,7 @@ logger.info('temlogger: test with extra fields', extra=extra)
 ### Example with Console
 
 ```bash
+export TEMLOGGER_APP_NAME='your-app-name'
 export TEMLOGGER_PROVIDER='console'
 export TEMLOGGER_ENVIRONMENT='staging'
 export TEMLOGGER_LOG_LEVEL='INFO'
@@ -220,10 +203,12 @@ import temlogger
 
 host = 'localhost'
 
+temlogger.config.set_app_name('your-app-name')
 temlogger.config.set_provider('logstash')
 temlogger.config.set_url('localhost')
 temlogger.config.set_port(5000)
 temlogger.config.set_environment('staging')
+temlogger.config.set_log_level('INFO')
 
 ```
 
@@ -247,7 +232,10 @@ The below example shows how register a handler `add_tracker_id_to_message` globa
 ```python
 import temlogger
 
-temlogger.config.set_provider('logstash')
+temlogger.config.set_app_name('your-app-name')
+temlogger.config.set_provider('console')
+temlogger.config.set_log_level('INFO')
+
 temlogger.config.setup_event_handlers([
     'temlogger.tests.base.add_tracker_id_to_message',
 ])
@@ -272,7 +260,9 @@ def add_user_id_key(message):
     message['user_id'] = 'User Id'
     return message
 
-temlogger.config.set_provider('logstash')
+temlogger.config.set_app_name('your-app-name')
+temlogger.config.set_provider('console')
+temlogger.config.set_log_level('INFO')
 
 logger = temlogger.getLogger('python-logger', event_handlers=[
     'temlogger.tests.base.add_tracker_id_to_message',

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,9 @@
 TemLogger
 =========
 
-**Temlogger** is a library that help send logs to different providers
-such ELK, StackDriver(Google Cloud Logging). Temlogger can be used in
-any python 3.6+ application.
+**Temlogger** is a library to sends logs to providers such as ELK and
+StackDriver(Google Cloud Logging). Temlogger can be used in any python
+3.6+ application.
 
 Features
 --------

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,9 @@
 TemLogger
 =========
 
-**Temlogger** is a library to send logs to ELK, StackDriver(Google Cloud
-Logging).
+**Temlogger** is a library that help send logs to different providers
+such ELK, StackDriver(Google Cloud Logging). Temlogger can be used in
+any python 3.6+ application.
 
 Features
 --------
@@ -43,87 +44,59 @@ Instalation
 
    pip install temlogger
 
-Usage
------
+Configuration
+-------------
 
-How to use temlogger
-~~~~~~~~~~~~~~~~~~~~
+Temlogger can be used with environment variables or programmatically.
 
-Can be used with environment variables:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Example of configuration with environment variables to Console provider:
 
 .. code:: bash
 
+   export TEMLOGGER_APP_NAME='your-app-name'
    export TEMLOGGER_PROVIDER='console'
    export TEMLOGGER_ENVIRONMENT='staging'
-   export TEMLOGGER_LOG_LEVEL='INFO' #Default: INFO, Acceptable values: DEBUG, INFO, WARNING, ERROR, FATAL, CRITICAL
+   export TEMLOGGER_LOG_LEVEL='INFO'
 
 .. code:: python
 
    import sys
    import temlogger
 
-   test_logger = temlogger.getLogger('python-console-logger')
-
-   test_logger.error('python-console: test console error message.')
    test_logger.info('python-console: test console info message.')
    test_logger.debug('python-console: debug message will not be displayed. Change level to "DEBUG"')
    test_logger.warning('python-console: test console warning message.')
 
-   # add extra field to console message
-   extra = {
-       'test_string': 'python version: ' + repr(sys.version_info),
-       'test_boolean': True,
-       'test_dict': {'a': 1, 'b': 'c'},
-       'test_float': 1.23,
-       'test_integer': 123,
-       'test_list': [1, 2, '3'],
-   }
-   test_logger.info('temlogger: test with extra fields', extra=extra)
-
-Can be used with explict parameters:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Example passing parameters directly to temlogger:
+Example of configuration programmatically to Console provider:
 
 .. code:: python
 
    import sys
    import temlogger
 
+   temlogger.config.set_app_name('your-app-name')
    temlogger.config.set_provider('console')
    temlogger.config.set_environment('staging')
    temlogger.config.set_log_level('INFO')
 
-   test_logger = temlogger.getLogger('python-console-logger')
-
    test_logger.info('python-console: test console info message.')
    test_logger.debug('python-console: debug message will not be displayed. Change level to "DEBUG"')
+   test_logger.warning('python-console: test console warning message.')
 
-   # add extra field to console message
-   extra = {
-       'test_string': 'python version: ' + repr(sys.version_info),
-       'test_boolean': True,
-       'test_dict': {'a': 1, 'b': 'c'},
-       'test_float': 1.23,
-       'test_integer': 123,
-       'test_list': [1, 2, '3'],
-   }
-   test_logger.info('temlogger: test with extra fields', extra=extra)
-
-Required parameters to setup Logstash Provider
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Parameters to setup Logstash Provider
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
+   export TEMLOGGER_APP_NAME='your-app-name'
    export TEMLOGGER_PROVIDER='logstash'
    export TEMLOGGER_URL='<logstash url>'
    export TEMLOGGER_PORT='<logstash port>'
    export TEMLOGGER_ENVIRONMENT='<your environment>'
    export TEMLOGGER_LOG_LEVEL='INFO'
 
-Required parameters to setup StackDriver Provider
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Parameters to setup StackDriver Provider
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The variable ``GOOGLE_APPLICATION_CREDENTIALS`` is now deprecated and
 your use isn’t recommended. Use ``TEMLOGGER_GOOGLE_CREDENTIALS_BASE64``
@@ -131,6 +104,7 @@ instead.
 
 ::
 
+   export TEMLOGGER_APP_NAME='your-app-name'
    export TEMLOGGER_PROVIDER='stackdriver'
    export TEMLOGGER_ENVIRONMENT='<your environment>'
    export TEMLOGGER_GOOGLE_CREDENTIALS_BASE64='<your google json creds as base64>'
@@ -142,14 +116,17 @@ To encode your google credentials use:
 
    base64 <google application credentials path>
 
-Required parameters to setup Console Provider
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Parameters to setup Console Provider
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
    export TEMLOGGER_PROVIDER='console'
    export TEMLOGGER_ENVIRONMENT='<your environment>'
    export TEMLOGGER_LOG_LEVEL='INFO'
+
+Usage Examples
+--------------
 
 Example with StackDriver
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -161,8 +138,10 @@ It’s recomended to assign just the needed permissions
 
 .. code:: bash
 
+   export TEMLOGGER_APP_NAME='your-app-name'
    export TEMLOGGER_PROVIDER='stackdriver'
    export TEMLOGGER_GOOGLE_CREDENTIALS_BASE64='<your google json creds as base64>'
+   export TEMLOGGER_ENVIRONMENT='staging'
    export TEMLOGGER_LOG_LEVEL='INFO'
 
 .. code:: python
@@ -190,6 +169,7 @@ Example with LogStash
 
 .. code:: bash
 
+   export TEMLOGGER_APP_NAME='your-app-name'
    export TEMLOGGER_PROVIDER='logstash'
    export TEMLOGGER_URL='localhost'
    export TEMLOGGER_PORT='5000'
@@ -221,6 +201,7 @@ Example with Console
 
 .. code:: bash
 
+   export TEMLOGGER_APP_NAME='your-app-name'
    export TEMLOGGER_PROVIDER='console'
    export TEMLOGGER_ENVIRONMENT='staging'
    export TEMLOGGER_LOG_LEVEL='INFO'
@@ -254,10 +235,12 @@ logging:
 
    host = 'localhost'
 
+   temlogger.config.set_app_name('your-app-name')
    temlogger.config.set_provider('logstash')
    temlogger.config.set_url('localhost')
    temlogger.config.set_port(5000)
    temlogger.config.set_environment('staging')
+   temlogger.config.set_log_level('INFO')
 
 Then in others files such as ``views.py``,\ ``models.py`` you can use in
 this way:
@@ -285,7 +268,10 @@ handler ``add_tracker_id_to_message`` globally.
 
    import temlogger
 
-   temlogger.config.set_provider('logstash')
+   temlogger.config.set_app_name('your-app-name')
+   temlogger.config.set_provider('console')
+   temlogger.config.set_log_level('INFO')
+
    temlogger.config.setup_event_handlers([
        'temlogger.tests.base.add_tracker_id_to_message',
    ])
@@ -312,7 +298,9 @@ one logger.
        message['user_id'] = 'User Id'
        return message
 
-   temlogger.config.set_provider('logstash')
+   temlogger.config.set_app_name('your-app-name')
+   temlogger.config.set_provider('console')
+   temlogger.config.set_log_level('INFO')
 
    logger = temlogger.getLogger('python-logger', event_handlers=[
        'temlogger.tests.base.add_tracker_id_to_message',

--- a/temlogger/providers/base.py
+++ b/temlogger/providers/base.py
@@ -8,9 +8,10 @@ from ..helpers import import_string_list
 
 class FormatterBase(LogstashFormatterBase):
 
-    def __init__(self, fqdn=False, environment='', event_handlers=[],
-                 *args, **kwargs):
+    def __init__(self, fqdn=False, app_name='', environment='',
+                 event_handlers=[], *args, **kwargs):
         super().__init__(message_type='', fqdn=fqdn, *args, **kwargs)
+        self.app_name = app_name
         self.environment = environment
         self.event_handlers = import_string_list(event_handlers)
 
@@ -31,6 +32,7 @@ class FormatterBase(LogstashFormatterBase):
             'host': self.host,
             'path': record.pathname,
             'environment': self.environment,
+            'app_name': self.app_name,
 
             # Extra Fields
             'level': record.levelname,

--- a/temlogger/temlogger.py
+++ b/temlogger/temlogger.py
@@ -89,7 +89,7 @@ class LoggingConfig:
     def get_app_name(self):
         return self._app_name or os.getenv('TEMLOGGER_APP_NAME', '')
 
-    def clear(self):
+    def reset(self):
         self._provider = ''
         self._url = ''
         self._port = ''
@@ -97,6 +97,7 @@ class LoggingConfig:
         self._google_credentials_base64 = ''
         self._event_handlers = []
         self._log_level = ''
+        self._app_name = ''
 
 
 class LoggerManager:

--- a/temlogger/temlogger.py
+++ b/temlogger/temlogger.py
@@ -29,6 +29,7 @@ class LoggingConfig:
     _google_credentials_base64 = ''
     _event_handlers = []
     _log_level = ''
+    _app_name = ''
 
     def set_provider(self, value):
         self._provider = value
@@ -82,6 +83,12 @@ class LoggingConfig:
         log_level_upper = self.get_log_level().upper()
         return logging.getLevelName(log_level_upper)
 
+    def set_app_name(self, value):
+        self._app_name = value
+
+    def get_app_name(self):
+        return self._app_name or os.getenv('TEMLOGGER_APP_NAME', '')
+
     def clear(self):
         self._provider = ''
         self._url = ''
@@ -128,6 +135,7 @@ class LoggerManager:
         from .providers.console import ConsoleFormatter
 
         logging_environment = config.get_environment()
+        app_name = config.get_app_name()
 
         logger = logging.getLogger(name)
         logger.setLevel(config.get_log_level_parsed())
@@ -135,6 +143,7 @@ class LoggerManager:
 
         handler = logging.StreamHandler()
         handler.setFormatter(ConsoleFormatter(
+            app_name=app_name,
             environment=logging_environment,
             event_handlers=event_handlers
         ))
@@ -149,6 +158,7 @@ class LoggerManager:
         logging_url = config.get_url()
         logging_port = config.get_port()
         logging_environment = config.get_environment()
+        app_name = config.get_app_name()
 
         logger = logging.getLogger(name)
         logger.setLevel(config.get_log_level_parsed())
@@ -156,6 +166,7 @@ class LoggerManager:
 
         handler = TCPLogstashHandler(logging_url, logging_port, version=1)
         handler.setFormatter(LogstashFormatter(
+            app_name=app_name,
             environment=logging_environment,
             event_handlers=event_handlers
         ))
@@ -170,6 +181,7 @@ class LoggerManager:
         import google.cloud.logging
         from .providers.stackdriver import StackDriverFormatter
 
+        app_name = config.get_app_name()
         logging_environment = config.get_environment()
         base64_cred = config.get_google_credentials_base64()
 
@@ -188,6 +200,7 @@ class LoggerManager:
 
         # Setup logger explicitly with this handler
         handler.setFormatter(StackDriverFormatter(
+            app_name=app_name,
             environment=logging_environment,
             event_handlers=event_handlers)
         )

--- a/temlogger/tests/base.py
+++ b/temlogger/tests/base.py
@@ -14,12 +14,13 @@ def clean_temlogger_config():
         'TEMLOGGER_PORT'
         'TEMLOGGER_ENVIRONMENT',
         'TEMLOGGER_LOG_LEVEL',
+        'TEMLOGGER_APP_NAME',
     ]
     for env in environments_to_clean:
         if env in os.environ:
             del os.environ[env]
 
-    temlogger.config.clear()
+    temlogger.config.reset()
 
 
 def add_tracker_id_to_message(message):

--- a/temlogger/tests/test_formatters.py
+++ b/temlogger/tests/test_formatters.py
@@ -50,6 +50,25 @@ class TestDefaultFormatter(unittest.TestCase):
         self.assertEqual(message['message'], log_message)
         self.assertEqual(message['environment'], 'develop')
 
+    def test_format_with_app_name_and_extra(self):
+        formater = StackDriverFormatter(
+            app_name='stackdriver-app', environment='develop'
+        )
+        log_message = 'Log entry message'
+
+        record = logging.makeLogRecord({
+            'msg': log_message, 'extra_field': 'Extra Field'}
+        )
+
+        message = formater.format(record)
+        payload = message['payload']
+
+        self.assertTrue('payload' in message)
+        self.assertEqual(payload['extra_field'], 'Extra Field')
+        self.assertEqual(message['message'], log_message)
+        self.assertEqual(message['environment'], 'develop')
+        self.assertEqual(message['app_name'], 'stackdriver-app')
+
 
 class TestLogstashFormatter(unittest.TestCase):
 

--- a/temlogger/tests/test_get_loggers.py
+++ b/temlogger/tests/test_get_loggers.py
@@ -25,6 +25,23 @@ class TestDefaultLogger(unittest.TestCase):
         self.assertEqual(logger.logging_provider, 'default')
         self.assertEqual(len(logger.handlers), 0)
 
+    def test_defaultlogger_with_app_name(self):
+        default_app_name = 'stackdriver-app'
+
+        temlogger.config.set_provider('default-app_name')
+        temlogger.config.set_app_name(default_app_name)
+
+        self.assertEqual(temlogger.config.get_app_name(), default_app_name)
+
+    def test_defaultlogger_with_app_name_as_environment(self):
+        default_app_name = 'stackdriver-app'
+
+        os.environ['TEMLOGGER_APP_NAME'] = default_app_name
+
+        temlogger.config.set_provider('default')
+
+        self.assertEqual(temlogger.config.get_app_name(), default_app_name)
+
 
 class TestLogstashLogger(unittest.TestCase):
 
@@ -131,16 +148,16 @@ class TestStackDriverLogger(unittest.TestCase):
             logging.INFO, 'StackDriver log', ())
 
     def test_stackdriver_with_credentials_base64(self):
-        self.valid_cred = encode_file_as_base64(VALID_GOOGLE_CREDENTIALS)
+        valid_cred = encode_file_as_base64(VALID_GOOGLE_CREDENTIALS)
 
         temlogger.config.set_provider('stackdriver')
-        temlogger.config.set_google_credentials_base64(self.valid_cred)
+        temlogger.config.set_google_credentials_base64(valid_cred)
         temlogger.getLogger('stackdriver-base64')
 
     def test_stackdriver_with_credentials_base64_as_environment(self):
-        self.valid_cred = encode_file_as_base64(VALID_GOOGLE_CREDENTIALS)
+        valid_cred = encode_file_as_base64(VALID_GOOGLE_CREDENTIALS)
 
-        os.environ['TEMLOGGER_GOOGLE_CREDENTIALS_BASE64'] = self.valid_cred
+        os.environ['TEMLOGGER_GOOGLE_CREDENTIALS_BASE64'] = valid_cred
 
         temlogger.config.set_provider('stackdriver')
         temlogger.getLogger('stackdriver-base64')

--- a/temlogger/tests/test_setup_event_handlers.py
+++ b/temlogger/tests/test_setup_event_handlers.py
@@ -28,6 +28,8 @@ class TestEventHandler(unittest.TestCase):
             return message
 
         temlogger.config.set_provider('logstash')
+        temlogger.config.set_app_name('test-app-name')
+        temlogger.config.set_environment('local')
         temlogger.config.setup_event_handlers([add_tracker_id])
 
         logger = temlogger.getLogger('first_handler')
@@ -45,7 +47,9 @@ class TestEventHandler(unittest.TestCase):
                 'host': socket.gethostname(),
                 'path': os.path.abspath(__file__),
                 'tracker_id': 'tracker_id_hex',
-                'environment': '', 'level': 'INFO',
+                'environment': 'local', 
+                'level': 'INFO',
+                'app_name': 'test-app-name',
                 'logger_name': logger.name,
                 'payload': {'stack_info': None}
             }
@@ -80,6 +84,9 @@ class TestEventHandler(unittest.TestCase):
             return message
 
         temlogger.config.set_provider('logstash')
+        temlogger.config.set_app_name('test-app-name')
+        temlogger.config.set_environment('local')
+
         temlogger.config.setup_event_handlers([
             tracker_id_param,
             add_request_id_param
@@ -101,7 +108,9 @@ class TestEventHandler(unittest.TestCase):
                 'path': os.path.abspath(__file__),
                 'tracker_id': 'tracker_id_hex',
                 'request_id': 'request_id_hex2',
-                'environment': '', 'level': 'INFO',
+                'environment': 'local', 
+                'level': 'INFO',
+                'app_name': 'test-app-name',
                 'logger_name': logger.name,
                 'payload': {'stack_info': None}
             }
@@ -134,6 +143,9 @@ class TestEventHandler(unittest.TestCase):
             return message
 
         temlogger.config.set_provider('logstash')
+        temlogger.config.set_app_name('test-app-name')
+        temlogger.config.set_environment('local')
+
         temlogger.config.setup_event_handlers([
             'temlogger.tests.base.add_tracker_id_to_message',
         ])
@@ -153,7 +165,9 @@ class TestEventHandler(unittest.TestCase):
                 'message': logger_message,
                 'host': socket.gethostname(),
                 'path': os.path.abspath(__file__),
-                'environment': '', 'level': 'INFO',
+                'environment': 'local', 
+                'level': 'INFO',
+                'app_name': 'test-app-name',
                 'logger_name': logger.name,
                 'payload': {'stack_info': None},
                 'tracker_id_global': 'tracker_id_value_global',
@@ -170,6 +184,9 @@ class TestEventHandler(unittest.TestCase):
             return message
 
         temlogger.config.set_provider('logstash')
+        temlogger.config.set_app_name('test-app-name')
+        temlogger.config.set_environment('local')
+
         temlogger.config.setup_event_handlers([
             'temlogger.tests.base.add_tracker_id_to_message',
             add_random_key_to_message,
@@ -190,7 +207,9 @@ class TestEventHandler(unittest.TestCase):
                 'message': logger_message,
                 'host': socket.gethostname(),
                 'path': os.path.abspath(__file__),
-                'environment': '', 'level': 'INFO',
+                'environment': 'local', 
+                'level': 'INFO',
+                'app_name': 'test-app-name',
                 'logger_name': logger.name,
                 'payload': {'stack_info': None},
                 'tracker_id_global': 'tracker_id_value_global',
@@ -208,6 +227,9 @@ class TestEventHandler(unittest.TestCase):
             return message
 
         temlogger.config.set_provider('logstash')
+        temlogger.config.set_app_name('test-app-name')
+        temlogger.config.set_environment('local')
+
         logger = temlogger.getLogger('five_handler', event_handlers=[
             add_random_key_to_message_local
         ])
@@ -226,8 +248,9 @@ class TestEventHandler(unittest.TestCase):
                 'message': logger_message,
                 'host': socket.gethostname(),
                 'path': os.path.abspath(__file__),
-                'environment': '',
+                'environment': 'local', 
                 'level': 'INFO',
+                'app_name': 'test-app-name',
                 'logger_name': logger.name,
                 'payload': {'stack_info': None},
                 'random_key': random_key,


### PR DESCRIPTION
This PR introduces the variable `TEMLOGGER_APP_NAME` to make more ease filter logs by applications name.